### PR TITLE
Update anonymous and remove unused functions

### DIFF
--- a/lib/data_types/node_id.ex
+++ b/lib/data_types/node_id.ex
@@ -184,7 +184,7 @@ defmodule ExOpcua.DataTypes.NodeId do
         } = n_id
       )
       when mask in [3, 5] do
-    ("ns=" <> Integer.to_string(namespace_idx) <> ";i=" <> identifier)
+    ("ns=" <> Integer.to_string(namespace_idx) <> ";s=" <> identifier)
     |> has_additional_to_string(n_id)
   end
 

--- a/lib/ex_opcua.ex
+++ b/lib/ex_opcua.ex
@@ -16,14 +16,6 @@ defmodule ExOpcua do
     Session.start_session(opts)
   end
 
-  def send(pid) do
-    GenServer.cast(pid, :send)
-  end
-
-  def read(pid) do
-    GenServer.call(pid, :read)
-  end
-
   def close_session(pid) do
     GenServer.call(pid, :close_session)
   end

--- a/lib/services/activate_session.ex
+++ b/lib/services/activate_session.ex
@@ -53,7 +53,7 @@ defmodule ExOpcua.Services.ActivateSession do
       0x00,
       0x00,
       0x00,
-      serialize_string("anonymous"),
+      serialize_string("Anonymous"),
       # signature data
       opc_null_value(),
       opc_null_value()

--- a/lib/session/server.ex
+++ b/lib/session/server.ex
@@ -52,16 +52,6 @@ defmodule ExOpcua.Session.Server do
     {:noreply, state}
   end
 
-  # # TODO: Just a garbage message for testing currently
-  # @impl GenServer
-  # def handle_cast(:send, %{socket: socket} = s) do
-  #   s = Session.check_session(s)
-  #   :gen_tcp.send(socket, Protocol.encode_message(:browse_request, s))
-  #   result = Protocol.recieve_message(socket)
-  #   IO.inspect(result)
-  #   {:noreply, s}
-  # end
-
   @impl GenServer
   def handle_call({:read_all, node_ids}, _from, %{socket: socket} = s) do
     s = Session.check_session(s)


### PR DESCRIPTION
WHY
---
- Activate session doesnt currently use UserIdentities and therefore needed an update to its hardcoded anonymous ID.
- NodeID wrongly parses string ids
- Unused functions can cause confusion

HOW
---
-Update NodeID to_string function
-Capitalize "anonymous"
-delete unused functions