### PR TITLE
Check session does not do what is intended

### DIFF
--- a/lib/services/create_session.ex
+++ b/lib/services/create_session.ex
@@ -17,10 +17,8 @@ defmodule ExOpcua.Services.CreateSession do
         %{
           session_id: session_id,
           auth_token: auth_token,
-          revised_session_timeout: round(revised_session_timeout),
+          revised_session_timeout: revised_session_timeout,
           server_session_signature: server_cert <> server_nonce,
-          session_expire_time:
-            DateTime.add(DateTime.utc_now(), revised_session_timeout, :millisecond),
           endpoint_descriptions: endpoint_descriptions
         }
       }
@@ -67,4 +65,3 @@ defmodule ExOpcua.Services.CreateSession do
   defp take_revised_timeout(<<revised_session_timeout::ldouble, rest::binary>>) do
     {round(revised_session_timeout), rest}
   end
-end

--- a/lib/session.ex
+++ b/lib/session.ex
@@ -222,20 +222,6 @@ defmodule ExOpcua.Session do
     end
   end
 
-  def check_session(
-        %State{
-          session_expire_time: expire_time
-        } = s
-      ) do
-    if DateTime.compare(DateTime.utc_now(), expire_time) == :lt do
-      s
-    else
-      s
-      |> create_session()
-      |> activate_session()
-    end
-  end
-
   def reset_state(%State{ip: ip, url: url, handler: handler, port: port}),
     do: %State{ip: ip, url: url, handler: handler, port: port}
 end

--- a/lib/session/server.ex
+++ b/lib/session/server.ex
@@ -54,8 +54,6 @@ defmodule ExOpcua.Session.Server do
 
   @impl GenServer
   def handle_call({:read_all, node_ids}, _from, %{socket: socket} = s) do
-    s = Session.check_session(s)
-
     {s, req} =
       node_ids
       |> Services.Read.encode_read_all(s)
@@ -70,8 +68,6 @@ defmodule ExOpcua.Session.Server do
 
   @impl GenServer
   def handle_call({:read_attrs, node_ids, attrs}, _from, %{socket: socket} = s) do
-    s = Session.check_session(s)
-
     {s, req} =
       node_ids
       |> Services.Read.encode_read_attrs(attrs, s)
@@ -87,7 +83,6 @@ defmodule ExOpcua.Session.Server do
   @impl GenServer
   def handle_call({:browse, node_id, opts}, _from, %{socket: socket} = s) do
     b_desc = struct(ExOpcua.DataTypes.BrowseDescription, [node_id: node_id] ++ opts)
-    s = Session.check_session(s)
 
     {s, req} =
       b_desc


### PR DESCRIPTION
WHY
---
- Sessions are closed by the server and do not need to be checked ahead of time.

HOW
---
- No longer check revised timeout
- Session crashes properly when session doesnt exist