### PR TITLE
Browse a more generic object reference type

### DIFF
--- a/lib/data_types/browse_description.ex
+++ b/lib/data_types/browse_description.ex
@@ -6,7 +6,7 @@ defmodule ExOpcua.DataTypes.BrowseDescription do
   defstruct [
     :node_id,
     browse_direction: :forward,
-    reference_type_id: %NodeId{encoding_mask: 0, identifier: 35},
+    reference_type_id: %NodeId{encoding_mask: 0, identifier: 33},
     include_subtypes: true,
     node_class_mask: 0,
     result_mask: 31


### PR DESCRIPTION
WHY
---
- Some servers use more than OrganizesBy subtypes. This change should handle those other types

HOW
---
- Change the default browseDescription to be a more generic parent type than Organizes